### PR TITLE
Fix: Improve real-time rendering of streaming messages

### DIFF
--- a/server/gemini-cli.js
+++ b/server/gemini-cli.js
@@ -320,10 +320,15 @@ async function spawnGemini(command, options = {}, ws) {
         return;
       }
       
-      // console.error('Gemini CLI stderr:', errorMsg);
+      // Treat stderr as part of the response stream
+      fullResponse += (fullResponse ? '\n' : '') + errorMsg;
+      
       ws.send(JSON.stringify({
-        type: 'gemini-error',
-        error: errorMsg
+        type: 'gemini-response',
+        data: {
+          type: 'message',
+          content: errorMsg
+        }
       }));
     });
     

--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -1538,20 +1538,48 @@ function ChatInterface({ selectedProject, selectedSession, ws, sendMessage, mess
                 }]);
               } else if (part.type === 'text' && part.text?.trim()) {
                 // Add regular text message
-                setChatMessages(prev => [...prev, {
-                  type: 'assistant',
-                  content: part.text,
-                  timestamp: new Date()
-                }]);
+                setChatMessages(prev => {
+                  const lastMessage = prev[prev.length - 1];
+                  if (lastMessage && lastMessage.type === 'assistant' && !lastMessage.isToolUse) {
+                    // Append to the last assistant message
+                    const updatedMessages = [...prev];
+                    updatedMessages[updatedMessages.length - 1] = {
+                      ...lastMessage,
+                      content: lastMessage.content + part.text
+                    };
+                    return updatedMessages;
+                  } else {
+                    // Create a new assistant message
+                    return [...prev, {
+                      type: 'assistant',
+                      content: part.text,
+                      timestamp: new Date()
+                    }];
+                  }
+                });
               }
             }
           } else if (typeof messageData.content === 'string' && messageData.content.trim()) {
             // Add regular text message
-            setChatMessages(prev => [...prev, {
-              type: 'assistant',
-              content: messageData.content,
-              timestamp: new Date()
-            }]);
+            setChatMessages(prev => {
+              const lastMessage = prev[prev.length - 1];
+              if (lastMessage && lastMessage.type === 'assistant' && !lastMessage.isToolUse) {
+                // Append to the last assistant message
+                const updatedMessages = [...prev];
+                updatedMessages[updatedMessages.length - 1] = {
+                  ...lastMessage,
+                  content: lastMessage.content + messageData.content
+                };
+                return updatedMessages;
+              } else {
+                // Create a new assistant message
+                return [...prev, {
+                  type: 'assistant',
+                  content: messageData.content,
+                  timestamp: new Date()
+                }];
+              }
+            });
           }
           
           // Handle tool results from user messages (these come separately)

--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -1634,6 +1634,13 @@ function ChatInterface({ selectedProject, selectedSession, ws, sendMessage, mess
           if (selectedProject && latestMessage.exitCode === 0) {
             localStorage.removeItem(`chat_messages_${selectedProject.name}`);
           }
+
+          // Fetch the latest session messages to ensure the UI is up-to-date
+          if (selectedProject && activeSessionId) {
+            loadSessionMessages(selectedProject.name, activeSessionId).then(messages => {
+              setSessionMessages(messages);
+            });
+          }
           break;
           
         case 'session-aborted':

--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -1578,11 +1578,25 @@ function ChatInterface({ selectedProject, selectedSession, ws, sendMessage, mess
           break;
           
         case 'gemini-output':
-          setChatMessages(prev => [...prev, {
-            type: 'assistant',
-            content: latestMessage.data,
-            timestamp: new Date()
-          }]);
+          setChatMessages(prev => {
+            const lastMessage = prev[prev.length - 1];
+            if (lastMessage && lastMessage.type === 'assistant' && !lastMessage.isToolUse) {
+              // Append to the last assistant message
+              const updatedMessages = [...prev];
+              updatedMessages[updatedMessages.length - 1] = {
+                ...lastMessage,
+                content: lastMessage.content + latestMessage.data
+              };
+              return updatedMessages;
+            } else {
+              // Create a new assistant message
+              return [...prev, {
+                type: 'assistant',
+                content: latestMessage.data,
+                timestamp: new Date()
+              }];
+            }
+          });
           break;
         case 'gemini-interactive-prompt':
           // Handle interactive prompts from CLI


### PR DESCRIPTION
This Pull Request addresses an issue where messages were rendered incorrectly when receiving a streaming response from the Gemini CLI. Previously, each data chunk of the response was incorrectly displayed as a new message with its own timestamp.

This update ensures that streaming responses are smoothly and correctly appended to a single message through the following changes:

- **Implemented Stream-Append Logic**: Modified the `gemini-response` event handler to append subsequent data chunks to the last message instead of creating new ones.
- **Corrected Timestamps**: Ensured that a single, complete streaming response generates only one timestamp, avoiding the clutter of new timestamps for each data chunk.
- **Handled Error Stream**: Integrated the standard error (stderr) from the Gemini CLI into the message stream to ensure error messages are displayed promptly.
- **Ensured Final Consistency**: After the streaming response is complete, the session messages are re-fetched to guarantee that the content displayed in the UI is perfectly consistent with the final, complete message.