### PR TITLE
Fix: Remove hardcoded Japanese prompts and messages

### DIFF
--- a/server/gemini-cli.js
+++ b/server/gemini-cli.js
@@ -82,7 +82,11 @@ async function spawnGemini(command, options = {}, ws) {
         // Include the full image paths in the prompt for Gemini to reference
         // Gemini CLI can read images from file paths in the prompt
         if (tempImagePaths.length > 0 && command && command.trim()) {
-          const imageNote = `\n\n[画像を添付しました: ${tempImagePaths.length}枚の画像があります。以下のパスに保存されています:]\n${tempImagePaths.map((p, i) => `${i + 1}. ${p}`).join('\n')}`;
+          const imageNote = `
+
+[Attached images: ${tempImagePaths.length} image(s) are available at the following paths:]
+${tempImagePaths.map((p, i) => `${i + 1}. ${p}`).join('
+')}`;
           const modifiedCommand = command + imageNote;
           
           // Update the command in args

--- a/server/gemini-cli.js
+++ b/server/gemini-cli.js
@@ -320,10 +320,15 @@ async function spawnGemini(command, options = {}, ws) {
         return;
       }
       
-      // console.error('Gemini CLI stderr:', errorMsg);
+      // Treat stderr as part of the response stream
+      fullResponse += (fullResponse ? '\n' : '') + errorMsg;
+      
       ws.send(JSON.stringify({
-        type: 'gemini-error',
-        error: errorMsg
+        type: 'gemini-response',
+        data: {
+          type: 'message',
+          content: errorMsg
+        }
       }));
     });
     

--- a/server/sessionManager.js
+++ b/server/sessionManager.js
@@ -109,17 +109,17 @@ class SessionManager {
     // Get last N messages for context
     const recentMessages = session.messages.slice(-maxMessages);
     
-    let context = '以下は過去の会話履歴です:\n\n';
+    let context = 'This is the past conversation history:\n\n';
     
     for (const msg of recentMessages) {
       if (msg.role === 'user') {
-        context += `ユーザー: ${msg.content}\n`;
+        context += `User: ${msg.content}\n`;
       } else {
-        context += `アシスタント: ${msg.content}\n`;
+        context += `Assistant: ${msg.content}\n`;
       }
     }
     
-    context += '\n上記の会話履歴を踏まえて、次の質問に答えてください:\n';
+    context += '\nBased on the conversation history above, please answer the next question:\n';
     
     return context;
   }

--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -1538,20 +1538,48 @@ function ChatInterface({ selectedProject, selectedSession, ws, sendMessage, mess
                 }]);
               } else if (part.type === 'text' && part.text?.trim()) {
                 // Add regular text message
-                setChatMessages(prev => [...prev, {
-                  type: 'assistant',
-                  content: part.text,
-                  timestamp: new Date()
-                }]);
+                setChatMessages(prev => {
+                  const lastMessage = prev[prev.length - 1];
+                  if (lastMessage && lastMessage.type === 'assistant' && !lastMessage.isToolUse) {
+                    // Append to the last assistant message
+                    const updatedMessages = [...prev];
+                    updatedMessages[updatedMessages.length - 1] = {
+                      ...lastMessage,
+                      content: lastMessage.content + part.text
+                    };
+                    return updatedMessages;
+                  } else {
+                    // Create a new assistant message
+                    return [...prev, {
+                      type: 'assistant',
+                      content: part.text,
+                      timestamp: new Date()
+                    }];
+                  }
+                });
               }
             }
           } else if (typeof messageData.content === 'string' && messageData.content.trim()) {
             // Add regular text message
-            setChatMessages(prev => [...prev, {
-              type: 'assistant',
-              content: messageData.content,
-              timestamp: new Date()
-            }]);
+            setChatMessages(prev => {
+              const lastMessage = prev[prev.length - 1];
+              if (lastMessage && lastMessage.type === 'assistant' && !lastMessage.isToolUse) {
+                // Append to the last assistant message
+                const updatedMessages = [...prev];
+                updatedMessages[updatedMessages.length - 1] = {
+                  ...lastMessage,
+                  content: lastMessage.content + messageData.content
+                };
+                return updatedMessages;
+              } else {
+                // Create a new assistant message
+                return [...prev, {
+                  type: 'assistant',
+                  content: messageData.content,
+                  timestamp: new Date()
+                }];
+              }
+            });
           }
           
           // Handle tool results from user messages (these come separately)

--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -1634,6 +1634,13 @@ function ChatInterface({ selectedProject, selectedSession, ws, sendMessage, mess
           if (selectedProject && latestMessage.exitCode === 0) {
             localStorage.removeItem(`chat_messages_${selectedProject.name}`);
           }
+
+          // Fetch the latest session messages to ensure the UI is up-to-date
+          if (selectedProject && activeSessionId) {
+            loadSessionMessages(selectedProject.name, activeSessionId).then(messages => {
+              setSessionMessages(messages);
+            });
+          }
           break;
           
         case 'session-aborted':

--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -1426,7 +1426,7 @@ function ChatInterface({ selectedProject, selectedSession, ws, sendMessage, mess
         setChatMessages(prev => [...prev, {
           id: `system-${Date.now()}`,
           type: 'system',
-          content: '⚙️ 設定が更新されました。',
+          content: '⚙️ Settings have been updated.',
           timestamp: new Date().toISOString()
         }]);
       }

--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -1578,11 +1578,25 @@ function ChatInterface({ selectedProject, selectedSession, ws, sendMessage, mess
           break;
           
         case 'gemini-output':
-          setChatMessages(prev => [...prev, {
-            type: 'assistant',
-            content: latestMessage.data,
-            timestamp: new Date()
-          }]);
+          setChatMessages(prev => {
+            const lastMessage = prev[prev.length - 1];
+            if (lastMessage && lastMessage.type === 'assistant' && !lastMessage.isToolUse) {
+              // Append to the last assistant message
+              const updatedMessages = [...prev];
+              updatedMessages[updatedMessages.length - 1] = {
+                ...lastMessage,
+                content: lastMessage.content + latestMessage.data
+              };
+              return updatedMessages;
+            } else {
+              // Create a new assistant message
+              return [...prev, {
+                type: 'assistant',
+                content: latestMessage.data,
+                timestamp: new Date()
+              }];
+            }
+          });
           break;
         case 'gemini-interactive-prompt':
           // Handle interactive prompts from CLI


### PR DESCRIPTION
This commit removes hardcoded Japanese text from several parts of the application to prevent the Gemini model from unexpectedly replying in Japanese.

- Replaced Japanese context builders in sessionManager.js with English.
- Updated a Japanese UI notification in ChatInterface.jsx to English.
- Changed the Japanese image attachment note in gemini-cli.js to English.