### PR TITLE
feat: Add Gemini 3 Flash and Pro preview models to settings

### DIFF
--- a/src/components/ToolsSettings.jsx
+++ b/src/components/ToolsSettings.jsx
@@ -66,6 +66,8 @@ function ToolsSettings({ isOpen, onClose }) {
   
   // Available Gemini models (tested and verified)
   const availableModels = [
+    { value: 'gemini-3-flash-preview', label: 'Gemini 3 Flash Preview', description: 'Next-generation fast model with advanced reasoning.' },
+    { value: 'gemini-3-pro-preview', label: 'Gemini 3 Pro Preview', description: 'Most capable next-generation model.' },
     { value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash', description: 'Fast and efficient latest model (Recommended)' },
     { value: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro', description: 'Most advanced model (Note: May have quota limits)' }
   ];


### PR DESCRIPTION
Update the available models list in ToolsSettings to include the next-generation Gemini 3 Flash Preview and Gemini 3 Pro Preview models.

🤖 Generated with [Gemini CLI](https://gemini.google.com/cli)